### PR TITLE
feat: 강의상세페이지 카카오 로그인 및 강의 신청 플로우 수정

### DIFF
--- a/src/utils/kakao-auth.ts
+++ b/src/utils/kakao-auth.ts
@@ -1,0 +1,45 @@
+import { supabase } from "@/utils/supabase";
+
+export async function getKakaoUserInfo(providerToken: string) {
+  try {
+    const response = await fetch("https://kapi.kakao.com/v2/user/me", {
+      headers: {
+        Authorization: `Bearer ${providerToken}`,
+        "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch Kakao user info");
+    }
+
+    const data = await response.json();
+    return {
+      phoneNumber: data.kakao_account?.phone_number,
+      name: data.kakao_account?.name,
+      email: data.kakao_account?.email,
+      profile: data.kakao_account?.profile,
+    };
+  } catch (error) {
+    console.error("Error fetching Kakao user info:", error);
+    return null;
+  }
+}
+
+export async function updateUserMetadata(phoneNumber?: string, name?: string) {
+  try {
+    const updateData: any = {};
+    if (phoneNumber) updateData.phone_number = phoneNumber;
+    if (name) updateData.name = name;
+
+    const { error } = await supabase.auth.updateUser({
+      data: updateData,
+    });
+
+    if (error) throw error;
+    return true;
+  } catch (error) {
+    console.error("Error updating user metadata:", error);
+    return false;
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용
- 카카오 비즈앱 심사 통과로 인해, 로그인 시 사용자로부터 '이름'과 '전화번호' 정보를 수집할 수 있게 되었습니다. 따라서 강의 신청 시 사용자 이름과 전화번호도 DB에 저장되게 로직 수정하였습니다.
  > Supabase를 통한 카카오 OAuth 로그인은 이메일·닉네임 등 기본 정보만 자동 저장되며, 
  > 전화번호나 실명은 provider token으로 카카오 API를 직접 호출해 조회하고, 이를 user metadata에 수동으로 업데이트하는 방식입니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 