### PR TITLE
fix: 카카오 로그인 로직 수정

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -32,7 +32,55 @@ export async function GET(request: NextRequest) {
       },
     );
 
-    await supabase.auth.exchangeCodeForSession(code);
+    const { data: sessionData, error } =
+      await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error && sessionData?.session) {
+      const { session } = sessionData;
+
+      // 카카오 로그인인 경우 사용자 정보 가져오기
+      if (
+        session.user.app_metadata?.provider === "kakao" &&
+        session.provider_token
+      ) {
+        try {
+          // 카카오 사용자 정보 가져오기
+          const kakaoResponse = await fetch(
+            "https://kapi.kakao.com/v2/user/me",
+            {
+              headers: {
+                Authorization: `Bearer ${session.provider_token}`,
+              },
+            },
+          );
+
+          if (kakaoResponse.ok) {
+            const kakaoData = await kakaoResponse.json();
+
+            const updates: { phone_number?: string; name?: string } = {};
+
+            // 전화번호 추출
+            if (kakaoData.kakao_account?.phone_number) {
+              updates.phone_number = kakaoData.kakao_account.phone_number;
+            }
+
+            // 이름 추출
+            if (kakaoData.kakao_account?.name) {
+              updates.name = kakaoData.kakao_account.name;
+            }
+
+            // 메타데이터 업데이트
+            if (Object.keys(updates).length > 0) {
+              await supabase.auth.updateUser({
+                data: updates,
+              });
+            }
+          }
+        } catch (error) {
+          console.error("Failed to fetch Kakao user info:", error);
+        }
+      }
+    }
   }
 
   // 로그인 후 리디렉션될 URL


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용
# 카카오 로그인 사용자 정보 처리 문제 해결

## 문제 발생 원인

### 커밋 801f674에서 발생한 변경사항
- 강의 신청 로직을 `useLectureApply.ts` 커스텀 훅으로 분리하면서 문제 발생
- 기존에는 `signInWithOAuth`에서 `scope` 파라미터를 설정하지 않았음
- 리팩토링 과정에서 `scope: "name account_email phone_number"`를 추가했지만, 이것만으로는 충분하지 않았음

### 근본적인 문제
1. **Supabase Auth 라이브러리 변경**
   - 기존: `@supabase/auth-helpers-nextjs`의 `createRouteHandlerClient` 사용
   - 변경 후: `@supabase/ssr`의 `createServerClient` 사용
   - 라이브러리 변경으로 인해 `provider_token` 처리 방식이 달라짐

2. **provider_token 접근성 문제**
   - 클라이언트 사이드의 `onAuthStateChange`에서 `session.provider_token`이 항상 제공되지 않음
   - OAuth 콜백 직후에만 `provider_token`이 사용 가능하고, 이후 세션에서는 보안상 제거됨

## 문제점

### 1. 기존 구조의 문제

- 카카오 로그인 후 사용자의 이름과 전화번호를 가져오는 로직이 클라이언트 사이드(`useLectureApply.ts`)에서 처리됨
- `onAuthStateChange` 이벤트에서 `session.provider_token`을 통해 카카오 API를 호출하려 했으나, 토큰이 제대로 전달되지 않는 경우가 발생
- 클라이언트에서 비동기적으로 처리되어 타이밍 이슈와 안정성 문제 존재

### 2. 구체적인 이슈

- `session.provider_token`이 클라이언트에서 접근할 때 undefined인 경우가 많음
- 로그인 직후 사용자 정보가 업데이트되지 않아 강의 신청 시 이름과 전화번호가 누락됨

## 해결 방법

### 1. 서버 사이드 처리로 변경

**파일**: `/src/app/api/auth/callback/route.ts`

```typescript
// 기존: 단순히 코드를 세션으로 교환만 함
await supabase.auth.exchangeCodeForSession(code);

// 변경: 세션 교환 후 카카오 사용자 정보 즉시 가져와서 업데이트
const { data: sessionData, error } =
  await supabase.auth.exchangeCodeForSession(code);

if (!error && sessionData?.session) {
  const { session } = sessionData;

  // 카카오 로그인인 경우 사용자 정보 가져오기
  if (
    session.user.app_metadata?.provider === "kakao" &&
    session.provider_token
  ) {
    // 카카오 API 호출하여 사용자 정보 가져오기
    const kakaoResponse = await fetch("https://kapi.kakao.com/v2/user/me", {
      headers: {
        Authorization: `Bearer ${session.provider_token}`,
      },
    });

    // 이름과 전화번호 추출 후 user_metadata 업데이트
  }
}
```

### 2. 클라이언트 코드 간소화

**파일**: `/src/hooks/useLectureApply.ts`

- 기존의 복잡한 카카오 정보 가져오기 로직 제거
- 서버에서 이미 업데이트된 사용자 정보를 신뢰하고 사용
- 로그인 후 자동 신청 로직만 유지

## 개선된 흐름

1. **사용자가 강의 신청 버튼 클릭**
   - 로그인 상태 확인
   - 미로그인 시 카카오 로그인 모달 표시

2. **카카오 로그인 진행**
   - OAuth 인증 후 `/api/auth/callback`으로 리다이렉트

3. **서버에서 사용자 정보 처리** (핵심 변경사항)
   - 인증 코드를 세션으로 교환
   - `session.provider_token`이 서버에서 바로 사용 가능
   - 카카오 API를 호출하여 사용자 정보 즉시 가져오기
   - Supabase user_metadata 업데이트

4. **클라이언트로 리다이렉트**
   - 이미 업데이트된 사용자 정보로 강의 신청 진행
   - 추가적인 API 호출 불필요

## 장점

1. **안정성 향상**: 서버 사이드에서 처리하여 토큰 접근 문제 해결
2. **성능 개선**: 클라이언트에서 추가 API 호출 불필요
3. **일관성**: 로그인 직후 즉시 사용자 정보가 업데이트됨
4. **단순화**: 클라이언트 코드가 간결해짐

## 주의사항

- 카카오 앱 설정에서 필요한 권한(name, phone_number)이 설정되어 있어야 함
- 서버 사이드에서 카카오 API 호출 시 에러 처리 포함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 