### PR TITLE
refactor: DB 구조 변경에 따른 강의 신청    프로세스 리팩토링

### DIFF
--- a/src/app/(main)/lecture/[id]/page.tsx
+++ b/src/app/(main)/lecture/[id]/page.tsx
@@ -18,7 +18,7 @@ export default function CourseDetailPage() {
   const [loading, setLoading] = useState(true);
 
   // 커스텀 훅 사용
-  const { isLoading, handleApplyClick } = useLectureApply(lecture);
+  const { isLoading, handleApplyClick } = useLectureApply(lectureId);
 
   useEffect(() => {
     const fetchLecture = async () => {

--- a/src/app/api/leads.ts
+++ b/src/app/api/leads.ts
@@ -1,9 +1,6 @@
 import { supabase } from "@/utils/supabase";
 
 interface LeadData {
-  name: string;
-  email: string;
-  phone_number?: string;
   subscribe: string;
 }
 
@@ -18,18 +15,9 @@ export const leadsApi = {
       throw new Error("인증이 필요합니다. 로그인 후 다시 시도해주세요.");
     }
 
-    if (user.email !== leadData.email) {
-      console.warn(
-        "Lead email does not match authenticated user email.",
-        `Authenticated: ${user.email}, Lead: ${leadData.email}`,
-      );
-    }
-
     const { error } = await supabase.from("leads").insert([
       {
-        name: leadData.name,
-        email: leadData.email,
-        phone_number: leadData.phone_number,
+        user_id: user.id,
         subscribe: leadData.subscribe,
       },
     ]);

--- a/src/components/LectureSidebar.tsx
+++ b/src/components/LectureSidebar.tsx
@@ -12,7 +12,7 @@ export function LectureSidebar({ lecture }: { lecture: LectureWithCoach }) {
     isLoading,
     handleLogin,
     handleApplyClick,
-  } = useLectureApply(lecture);
+  } = useLectureApply(lecture.id);
 
   return (
     <div className="h-fit lg:sticky lg:top-28">

--- a/src/hooks/useLectureApply.ts
+++ b/src/hooks/useLectureApply.ts
@@ -2,9 +2,8 @@ import { useState, useEffect, useCallback } from "react";
 import { User } from "@supabase/supabase-js";
 import { supabase } from "@/utils/supabase";
 import { leadsApi } from "@/app/api/leads";
-import { LectureWithCoach } from "@/types/lectures";
 
-export function useLectureApply(lecture: LectureWithCoach | null) {
+export function useLectureApply(lectureId: string | null) {
   const [modalStatus, setModalStatus] = useState<
     "hidden" | "login" | "success"
   >("hidden");
@@ -38,14 +37,14 @@ export function useLectureApply(lecture: LectureWithCoach | null) {
   };
 
   const handleApply = useCallback(async () => {
-    if (!lecture) return;
+    if (!lectureId) return;
 
     setIsLoading(true);
     setError(null);
 
     try {
       await leadsApi.createLead({
-        subscribe: lecture.id,
+        subscribe: lectureId,
       });
       setModalStatus("success");
     } catch (err) {
@@ -57,7 +56,7 @@ export function useLectureApply(lecture: LectureWithCoach | null) {
     } finally {
       setIsLoading(false);
     }
-  }, [lecture]);
+  }, [lectureId]);
 
   const handleApplyClick = () => {
     if (!user) {

--- a/src/hooks/useLectureApply.ts
+++ b/src/hooks/useLectureApply.ts
@@ -37,33 +37,27 @@ export function useLectureApply(lecture: LectureWithCoach | null) {
     }
   };
 
-  const handleApply = useCallback(
-    async (currentUser: User) => {
-      if (!lecture) return;
+  const handleApply = useCallback(async () => {
+    if (!lecture) return;
 
-      setIsLoading(true);
-      setError(null);
+    setIsLoading(true);
+    setError(null);
 
-      try {
-        await leadsApi.createLead({
-          name: currentUser.user_metadata?.name || "",
-          email: currentUser.email || "",
-          phone_number: currentUser.user_metadata?.phone_number || "",
-          subscribe: lecture.id,
-        });
-        setModalStatus("success");
-      } catch (err) {
-        if (err instanceof Error) {
-          setError(err.message);
-        } else {
-          setError("알 수 없는 오류가 발생하여 신청에 실패했습니다.");
-        }
-      } finally {
-        setIsLoading(false);
+    try {
+      await leadsApi.createLead({
+        subscribe: lecture.id,
+      });
+      setModalStatus("success");
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("오류가 발생하여 신청에 실패했습니다.");
       }
-    },
-    [lecture],
-  );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [lecture]);
 
   const handleApplyClick = () => {
     if (!user) {
@@ -71,7 +65,7 @@ export function useLectureApply(lecture: LectureWithCoach | null) {
       setModalStatus("login");
       return;
     }
-    handleApply(user);
+    handleApply();
   };
 
   useEffect(() => {
@@ -101,6 +95,7 @@ export function useLectureApply(lecture: LectureWithCoach | null) {
 
         // 로그인 후 자동 신청
         if (event === "SIGNED_IN" && applyAfterLogin) {
+          // TODO 꼭 필요한 로직인지? 검증 필
           // 서버에서 사용자 정보를 업데이트한 후 최신 정보 가져오기
           const {
             data: { user: updatedUser },
@@ -110,7 +105,7 @@ export function useLectureApply(lecture: LectureWithCoach | null) {
             setUser(updatedUser);
             setApplyAfterLogin(false);
             setModalStatus("hidden");
-            handleApply(updatedUser);
+            handleApply();
           }
         }
       } else {


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용
- 구조 변경에 따라 사용자 정보 관리 방식을 개선하고 관련 로직을 리팩토링했습니다.
### 1. DB 스키마 변경

**기존 구조:**
```sql
leads 테이블:
- name, email, phone_number (중복 저장)
- subscribe (강의 ID)
```

**변경된 구조:**
```sql
leads 테이블:
- user_id (FK to profiles)
- subscribe (강의 ID)

profiles 테이블:
- id, email, name, phone_number (중앙 집중화)
```

### 2. 구현 변경사항

#### 카카오 로그인 콜백 (`src/app/api/auth/callback/route.ts`)
- 카카오 로그인 성공 후 `provider_token`을 사용하여 카카오 API에서 사용자 정보 조회
- 이름과 전화번호를 추출하여 `profiles` 테이블에 upsert
- 필수 정보(이름, 전화번호) 누락 시 에러 페이지로 리디렉션

#### leads API (`src/app/api/leads.ts`)
- 기존: `name`, `email`, `phone_number` 필드를 직접 저장
- 변경: `user_id`와 `subscribe`(강의 ID)만 저장
- 사용자 정보는 `profiles` 테이블에서 참조하도록 정규화

#### useLectureApply 훅
- 파라미터를 `LectureWithCoach` 객체에서 `lectureId` 문자열로 변경
- 불필요한 카카오 사용자 정보 업데이트 로직 제거
- 코드 간소화 및 책임 분리

### 3. 사용자 플로우
1. 강의 신청 버튼 클릭
2. 미로그인 시 카카오 로그인 진행
3. 카카오 OAuth 완료 후 사용자 정보 자동 수집 및 저장
4. 로그인 완료 후 자동으로 강의 신청 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
