### PR TITLE
feat: 강의 신청 상태 관리 및 중복 신청 방지 기능 추가

### DIFF
--- a/src/app/api/leads.ts
+++ b/src/app/api/leads.ts
@@ -1,6 +1,31 @@
 import { supabase } from "@/utils/supabase";
 
 export const leadsApi = {
+  isApplied: async (lectureId: string): Promise<boolean> => {
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return false;
+    }
+
+    const { data, error } = await supabase
+      .from("leads")
+      .select("id")
+      .eq("user_id", user.id)
+      .eq("subscribe", lectureId)
+      .single();
+
+    if (error && error.code !== "PGRST116") {
+      console.error("Error checking lead:", error);
+      return false;
+    }
+
+    return !!data;
+  },
+
   createLead: async (subscribe?: string | null): Promise<void> => {
     const {
       data: { user },

--- a/src/components/LectureSidebar.tsx
+++ b/src/components/LectureSidebar.tsx
@@ -12,6 +12,7 @@ export function LectureSidebar({ lecture }: { lecture: LectureWithCoach }) {
     isLoading,
     handleLogin,
     handleApplyClick,
+    isApplied,
   } = useLectureApply(lecture.id);
 
   return (
@@ -49,10 +50,16 @@ export function LectureSidebar({ lecture }: { lecture: LectureWithCoach }) {
 
         <button
           onClick={handleApplyClick}
-          disabled={isLoading}
-          className="w-full rounded-lg bg-violet-600 px-6 py-4 text-lg font-bold text-white transition-colors duration-200 hover:bg-violet-700 disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={isLoading || isApplied}
+          className={`w-full rounded-lg px-6 py-4 text-lg font-bold text-white transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50 ${
+            isApplied ? "bg-gray-400" : "bg-violet-600 hover:bg-violet-700"
+          }`}
         >
-          {isLoading ? "신청하는 중..." : "무료강의 신청하기"}
+          {isLoading
+            ? "신청하는 중..."
+            : isApplied
+              ? "무료강의 신청완료"
+              : "무료강의 신청하기"}
         </button>
 
         <CountdownTimer deadline={lecture.apply_deadline} />


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
-  강의 신청 버튼의 상태를 실시간으로 관리하고 중복 신청을 방지하는 기능을 구현했습니다.
  ### 1. 신청 여부 확인 API 추가
  - `leadsApi.isApplied()`: 사용자의 특정 강의 신청 여부를 확인하는 함수
  - leads 테이블에서 user_id와 subscribe(강의 ID)로 조회

  ### 2. 신청 상태 관리 로직 개선
  - `useLectureApply` 훅에 `isApplied` 상태 추가
  - 페이지 로드 시 자동으로 신청 여부 확인
  - 신청 성공 후 즉시 상태 업데이트로 UI 반영

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 