### PR TITLE
feat: 강의 신청 시 웹훅 연동 추가

### DIFF
--- a/src/app/api/leads.ts
+++ b/src/app/api/leads.ts
@@ -16,7 +16,7 @@ export const leadsApi = {
       .select("id")
       .eq("user_id", user.id)
       .eq("subscribe", lectureId)
-      .single();
+      .maybeSingle();
 
     if (error && error.code !== "PGRST116") {
       console.error("Error checking lead:", error);

--- a/src/app/api/lectures/register/route.ts
+++ b/src/app/api/lectures/register/route.ts
@@ -79,7 +79,8 @@ export async function POST(request: Request) {
       },
     );
 
-    return NextResponse.json({ success: true });
+    const result = await webhookResponse.json();
+    return NextResponse.json(result);
   } catch (error) {
     console.error("Webhook 호출 오류:", error);
     return NextResponse.json(

--- a/src/app/api/lectures/register/route.ts
+++ b/src/app/api/lectures/register/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function POST(request: Request) {
+  try {
+    const cookieStore = await cookies();
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(cookiesToSet) {
+            try {
+              cookiesToSet.forEach(({ name, value, options }) =>
+                cookieStore.set(name, value, options),
+              );
+            } catch {
+              // Server Component에서 호출됨 - 무시 가능
+            }
+          },
+        },
+      },
+    );
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "인증이 필요합니다." },
+        { status: 401 },
+      );
+    }
+
+    const { lectureId } = await request.json();
+
+    if (!lectureId) {
+      return NextResponse.json(
+        { error: "강의 ID가 필요합니다." },
+        { status: 400 },
+      );
+    }
+
+    // 클라이언트의 데이터 조작을 방지를 위해 서버에서 조회
+    // profiles 조회는 단일 행 조회라 빠르고, id에 인덱스가 있어 성능 문제도 없음
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select("name, phone_number")
+      .eq("id", user.id)
+      .single();
+
+    if (profileError || !profile) {
+      return NextResponse.json(
+        { error: "사용자 정보를 찾을 수 없습니다." },
+        { status: 404 },
+      );
+    }
+
+    const webhookData = {
+      name: profile.name,
+      email: user.email,
+      phone_number: profile.phone_number,
+      lectureId: lectureId,
+    };
+
+    const webhookResponse = await fetch(
+      "https://aiinfrafs.app.n8n.cloud/webhook/lecture-register",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(webhookData),
+      },
+    );
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Webhook 호출 오류:", error);
+    return NextResponse.json(
+      { error: "Webhook 호출 중 오류가 발생했습니다." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/hooks/useLectureApply.ts
+++ b/src/hooks/useLectureApply.ts
@@ -19,7 +19,26 @@ export function useLectureApply(lectureId: string | null) {
     setApplyError(null);
 
     try {
+      // 1. leads 테이블에 신청 정보 저장
       await leadsApi.createLead(lectureId);
+
+      // 2. webhook 호출 (실패해도 신청은 성공으로 처리)
+      try {
+        const response = await fetch("/api/lectures/register", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ lectureId }),
+        });
+
+        if (!response.ok) {
+          console.error("Webhook 호출 실패:", await response.text());
+        }
+      } catch (webhookError) {
+        console.error("Webhook 호출 중 오류:", webhookError);
+      }
+
       setModalStatus("success");
       setIsApplied(true); // 신청 성공 시 상태 업데이트
     } catch (err) {


### PR DESCRIPTION
## #️⃣연관된 이슈
> 

## 📝작업 내용
- 강의 신청 프로세스에 웹훅 연동을 추가했습니다.
### 1. 강의 신청 웹훅 연동
- **새로운 API 라우트 추가** (`/api/lectures/register`)
  - 사용자 인증 확인 및 프로필 정보 조회
  - n8n 웹훅으로 신청 정보 전달
  - 웹훅 응답 결과를 클라이언트에 반환

### 2. leads API 개선
  - `maybeSingle()` 사용으로 불필요한 에러 로그 제거
### 주요 로직 변경
1. **웹훅 호출 프로세스**
   ```typescript
   // 사용자 정보 → 웹훅 데이터 구성 → n8n 호출 → 응답 반환
   const webhookData = {
     name: profile.name,
     email: user.email,
     phone_number: profile.phone_number,
     lectureId: lectureId,
   };
   ```

2. **신청 여부 확인 개선**
   ```typescript
   // .single() → .maybeSingle() 변경으로 에러 핸들링 개선
   const { data, error } = await supabase
     .from("leads")
     .select("id")
     .eq("user_id", user.id)
     .eq("subscribe", parseInt(lectureId))
     .maybeSingle();
   ```


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

>
