### PR TITLE
feat: 강의 관리 복제 기능 추가 및 

### DIFF
--- a/src/app/admin/(dashboard)/lectures/page.tsx
+++ b/src/app/admin/(dashboard)/lectures/page.tsx
@@ -151,13 +151,22 @@ export default function LecturesPage() {
                       </td>
                       <td className="px-6 py-4">
                         <div className="text-sm text-gray-900">
-                          {new Date(lecture.start_date).toLocaleDateString()}
-                        </div>
-                        <div className="text-sm text-gray-500">
-                          신청마감:{" "}
-                          {new Date(
-                            lecture.apply_deadline,
-                          ).toLocaleDateString()}
+                          {(() => {
+                            const dateStr = lecture.start_date;
+                            const date = dateStr.substring(0, 10);
+                            const time = dateStr.substring(11, 16);
+                            const [hour, minute] = time.split(":");
+                            const hourNum = parseInt(hour);
+                            const period = hourNum >= 12 ? "오후" : "오전";
+                            const displayHour =
+                              hourNum > 12
+                                ? hourNum - 12
+                                : hourNum === 0
+                                  ? 12
+                                  : hourNum;
+
+                            return `${date} ${period} ${displayHour.toString().padStart(2, "0")}:${minute}`;
+                          })()}
                         </div>
                       </td>
                       <td className="px-6 py-4">

--- a/src/app/admin/(dashboard)/lectures/page.tsx
+++ b/src/app/admin/(dashboard)/lectures/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { LectureWithCoach } from "@/types/lectures";
-import { Edit, Trash2, Plus } from "lucide-react";
+import { Edit, Trash2, Plus, Copy } from "lucide-react";
 import Image from "next/image";
 import LectureModal from "@/components/admin/lectures/LectureModal";
 import { lecturesApi } from "@/app/api/lectures";
@@ -11,6 +11,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 export default function LecturesPage() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
+  const [isDuplicateMode, setIsDuplicateMode] = useState(false);
   const [selectedLecture, setSelectedLecture] =
     useState<LectureWithCoach | null>(null);
   const queryClient = useQueryClient();
@@ -57,10 +58,17 @@ export default function LecturesPage() {
     }
   };
 
-  // 모달 열기 (생성/수정 통합)
-  const openModal = (lecture: LectureWithCoach | null = null) => {
-    setIsEditMode(!!lecture); // lecture가 있으면 수정 모드, 없으면 생성 모드
-    setSelectedLecture(lecture);
+  // 모달 열기 (생성/수정/복제 통합)
+  const openModal = (lecture: LectureWithCoach | null = null, duplicate: boolean = false) => {
+    if (duplicate && lecture) {
+      setIsEditMode(false);
+      setIsDuplicateMode(true);
+      setSelectedLecture(lecture);
+    } else {
+      setIsEditMode(!!lecture && !duplicate);
+      setIsDuplicateMode(false);
+      setSelectedLecture(lecture);
+    }
     setIsModalOpen(true);
   };
 
@@ -68,6 +76,7 @@ export default function LecturesPage() {
   const closeModal = () => {
     setIsModalOpen(false);
     setIsEditMode(false);
+    setIsDuplicateMode(false);
     setSelectedLecture(null);
   };
 
@@ -179,12 +188,21 @@ export default function LecturesPage() {
                           <button
                             onClick={() => openModal(lecture)}
                             className="rounded-lg p-2 text-gray-600 transition-colors hover:bg-gray-100 hover:text-blue-600"
+                            title="수정"
                           >
                             <Edit className="h-4 w-4" />
                           </button>
                           <button
+                            onClick={() => openModal(lecture, true)}
+                            className="rounded-lg p-2 text-gray-600 transition-colors hover:bg-gray-100 hover:text-green-600"
+                            title="복제"
+                          >
+                            <Copy className="h-4 w-4" />
+                          </button>
+                          <button
                             onClick={() => handleDeleteLecture(lecture)}
                             className="rounded-lg p-2 text-gray-600 transition-colors hover:bg-gray-100 hover:text-red-600"
+                            title="삭제"
                           >
                             <Trash2 className="h-4 w-4" />
                           </button>
@@ -203,6 +221,7 @@ export default function LecturesPage() {
         isOpen={isModalOpen}
         onClose={closeModal}
         isEdit={isEditMode}
+        isDuplicate={isDuplicateMode}
         lectureData={selectedLecture}
       />
     </div>

--- a/src/app/api/lectures.ts
+++ b/src/app/api/lectures.ts
@@ -51,7 +51,6 @@ export const lecturesApi = {
         content_url: formData.content_url,
         url: formData.url,
         start_date: formData.start_date,
-        apply_deadline: formData.apply_deadline,
         price: formData.price,
         coach_id: formData.coach_id,
       };
@@ -76,7 +75,6 @@ export const lecturesApi = {
         content_url: insertedLecture.content_url,
         url: insertedLecture.url,
         start_date: insertedLecture.start_date,
-        apply_deadline: insertedLecture.apply_deadline,
         price: insertedLecture.price,
         coach_id: insertedLecture.coach_id,
         updated_at: insertedLecture.updated_at,
@@ -225,7 +223,6 @@ export const lecturesApi = {
         content_url: updatedLecture.content_url,
         url: updatedLecture.url,
         start_date: updatedLecture.start_date,
-        apply_deadline: updatedLecture.apply_deadline,
         price: updatedLecture.price,
         coach_id: updatedLecture.coach_id,
         updated_at: updatedLecture.updated_at,

--- a/src/app/api/lectures.ts
+++ b/src/app/api/lectures.ts
@@ -4,7 +4,7 @@ import { storageApi } from "@/app/api/storage";
 
 export interface CreateLectureParams {
   formData: CreateLectureForm;
-  thumbnailFile: File;
+  thumbnailFile?: File;
   contentImageFiles?: File[];
   isDuplicate?: boolean;
 }

--- a/src/components/LectureSidebar.tsx
+++ b/src/components/LectureSidebar.tsx
@@ -62,7 +62,7 @@ export function LectureSidebar({ lecture }: { lecture: LectureWithCoach }) {
               : "무료강의 신청하기"}
         </button>
 
-        <CountdownTimer deadline={lecture.apply_deadline} />
+        <CountdownTimer deadline={lecture.start_date} />
       </div>
 
       <InfoModal

--- a/src/components/MobileFloatingBar.tsx
+++ b/src/components/MobileFloatingBar.tsx
@@ -44,7 +44,7 @@ export function MobileFloatingBar({
           : "pointer-events-none translate-y-full opacity-0"
       }`}
     >
-      <CountdownTimer deadline={lecture.apply_deadline} />
+      <CountdownTimer deadline={lecture.start_date} />
       <div className="mx-auto mt-1 flex w-full max-w-[900px] items-center justify-between rounded-xl bg-[#121212] shadow-md md:border md:border-neutral-800 md:p-[10px] md:pl-[30px]">
         <div className="hidden items-end gap-x-5 md:flex">
           <span className="text-lg font-semibold text-red-500">무료</span>

--- a/src/components/admin/lectures/LectureModal.tsx
+++ b/src/components/admin/lectures/LectureModal.tsx
@@ -14,6 +14,7 @@ interface LectureModalProps {
   isOpen: boolean;
   onClose: () => void;
   isEdit?: boolean;
+  isDuplicate?: boolean;
   lectureData?: LectureWithCoach | null;
 }
 
@@ -21,6 +22,7 @@ export default function LectureModal({
   isOpen,
   onClose,
   isEdit = false,
+  isDuplicate = false,
   lectureData = null,
 }: LectureModalProps) {
   const [thumbnailFile, setThumbnailFile] = useState<File | null>(null);
@@ -50,7 +52,7 @@ export default function LectureModal({
       content_text: "",
       url: "",
       start_date: "",
-      price: "",
+      price: "무료",
       coach_id: "",
     },
   });
@@ -71,21 +73,28 @@ export default function LectureModal({
     console.error("강사 목록 조회 실패:", coachesError);
   }
 
-  // 편집 모드일 때 폼 데이터 초기화
+  // 편집 모드 또는 복제 모드일 때 폼 데이터 초기화
   useEffect(() => {
-    if (isEdit && lectureData && isOpen) {
+    if ((isEdit || isDuplicate) && lectureData && isOpen) {
       setValue("title", lectureData.title);
       setValue("description", lectureData.description);
       setValue("url", lectureData.url);
       setValue("content_url", lectureData.content_url || "");
       setValue("content_text", lectureData.content_text || "");
-      setValue(
-        "start_date",
-        new Date(lectureData.start_date).toISOString().slice(0, 16),
-      );
+      
+      // 복제 모드에서는 시작 날짜를 비워두고, 편집 모드에서는 기존 날짜 사용
+      if (isDuplicate) {
+        setValue("start_date", "");
+      } else {
+        setValue(
+          "start_date",
+          new Date(lectureData.start_date).toISOString().slice(0, 16),
+        );
+      }
+      
       setValue("price", lectureData.price.toString());
 
-      // 기존 이미지 URL을 폼 필드에도 설정
+      // 복제 모드에서도 이미지를 그대로 복사
       setValue("thumbnail", lectureData.thumbnail || null);
       // lectureData.content_image는 콤마로 구분된 문자열이므로, 이를 배열로 변환합니다.
       const existingImages = lectureData.content_image
@@ -100,20 +109,20 @@ export default function LectureModal({
       if (lectureData.content_image) {
         setContentImagePreviews(existingImages);
       }
-    } else if (!isEdit) {
+    } else if (!isEdit && !isDuplicate) {
       reset();
       setThumbnailPreview("");
       setContentImagePreviews([]);
       setDeletedImageUrls([]);
     }
-  }, [isEdit, lectureData, isOpen, setValue, reset]);
+  }, [isEdit, isDuplicate, lectureData, isOpen, setValue, reset]);
 
   // 코치 목록이 로드된 후 coach_id 설정
   useEffect(() => {
-    if (isEdit && lectureData && coaches.length > 0) {
+    if ((isEdit || isDuplicate) && lectureData && coaches.length > 0) {
       setValue("coach_id", lectureData.coach_id.toString());
     }
-  }, [isEdit, lectureData, coaches, setValue]);
+  }, [isEdit, isDuplicate, lectureData, coaches, setValue]);
 
   // 미리보기 URL 정리 (메모리 누수 방지)
   useEffect(() => {
@@ -159,7 +168,7 @@ export default function LectureModal({
 
   const { mutate, isPending: isSubmitting } = useMutation({
     mutationFn: (data: CreateLectureForm) => {
-      if (isEdit && lectureData) {
+      if (isEdit && lectureData && !isDuplicate) {
         // 편집 모드
         const originalImages = Array.isArray(lectureData.content_image)
           ? lectureData.content_image
@@ -177,12 +186,27 @@ export default function LectureModal({
           remainingImages, // 업데이트된 기존 이미지 목록
           deletedImageUrls, // 삭제할 이미지 URL 목록
         );
+      } else if (isDuplicate && lectureData) {
+        // 복제 모드 - 기존 이미지를 그대로 사용하여 새 강의 생성
+        const duplicateData = {
+          ...data,
+          thumbnail: data.thumbnail || lectureData.thumbnail,
+          content_image: data.content_image || lectureData.content_image,
+        };
+        
+        return lecturesApi.createLecture({
+          formData: duplicateData,
+          thumbnailFile: undefined,
+          contentImageFiles: [],
+          isDuplicate: true,
+        });
       } else {
         // 생성 모드
         return lecturesApi.createLecture({
           formData: data,
           thumbnailFile: thumbnailFile!,
           contentImageFiles: contentImageFiles,
+          isDuplicate: false,
         });
       }
     },
@@ -191,7 +215,9 @@ export default function LectureModal({
       alert(
         isEdit
           ? "강의가 성공적으로 수정되었습니다!"
-          : "강의가 성공적으로 생성되었습니다!",
+          : isDuplicate
+            ? "강의가 성공적으로 복제되었습니다!"
+            : "강의가 성공적으로 생성되었습니다!",
       );
       handleClose();
     },
@@ -206,8 +232,8 @@ export default function LectureModal({
   });
 
   const onSubmit = (data: CreateLectureForm) => {
-    // 편집 모드가 아닐 때만 파일 필수 체크
-    if (!isEdit) {
+    // 생성 모드일 때만 파일 필수 체크
+    if (!isEdit && !isDuplicate) {
       if (!thumbnailFile) {
         alert("썸네일 이미지는 필수입니다.");
         return;
@@ -239,7 +265,7 @@ export default function LectureModal({
         >
           <div className="mb-6 flex items-center justify-between">
             <h2 className="text-lg font-semibold">
-              {isEdit ? "강의 수정" : "새 강의 추가"}
+              {isEdit ? "강의 수정" : isDuplicate ? "강의 복제" : "새 강의 추가"}
             </h2>
             <button
               onClick={handleClose}
@@ -327,7 +353,7 @@ export default function LectureModal({
             {/* 썸네일 이미지 */}
             <div>
               <label className="mb-1 block text-sm font-medium text-gray-700">
-                썸네일 이미지 {!isEdit && "*"}
+                썸네일 이미지 {!isEdit && !isDuplicate && "*"}
               </label>
               <input
                 type="file"
@@ -352,7 +378,7 @@ export default function LectureModal({
                     setThumbnailPreview("");
                   }
                 }}
-                required={!isEdit}
+                required={!isEdit && !isDuplicate}
                 className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm file:mr-4 file:rounded-lg file:border-0 file:bg-gray-50 file:px-4 file:py-2 file:text-sm file:font-medium file:text-gray-700 hover:file:bg-gray-100 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
               />
 
@@ -380,12 +406,12 @@ export default function LectureModal({
                 </div>
               )}
 
-              {!isEdit && !thumbnailFile && (
+              {!isEdit && !isDuplicate && !thumbnailFile && (
                 <p className="mt-1 text-xs text-red-500">
                   썸네일 이미지는 필수입니다.
                 </p>
               )}
-              {isEdit && (
+              {(isEdit || isDuplicate) && (
                 <p className="mt-1 text-xs text-gray-500">
                   새 이미지를 선택하지 않으면 기존 이미지가 유지됩니다.
                 </p>

--- a/src/components/admin/lectures/LectureModal.tsx
+++ b/src/components/admin/lectures/LectureModal.tsx
@@ -50,7 +50,6 @@ export default function LectureModal({
       content_text: "",
       url: "",
       start_date: "",
-      apply_deadline: "",
       price: "",
       coach_id: "",
     },
@@ -83,10 +82,6 @@ export default function LectureModal({
       setValue(
         "start_date",
         new Date(lectureData.start_date).toISOString().slice(0, 16),
-      );
-      setValue(
-        "apply_deadline",
-        new Date(lectureData.apply_deadline).toISOString().slice(0, 10),
       );
       setValue("price", lectureData.price.toString());
 
@@ -526,44 +521,23 @@ export default function LectureModal({
               )}
             </div>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              {/* 시작 날짜 */}
-              <div>
-                <label className="mb-1 block text-sm font-medium text-gray-700">
-                  시작 날짜 *
-                </label>
-                <input
-                  type="datetime-local"
-                  {...register("start_date", {
-                    required: "시작 날짜는 필수입니다.",
-                  })}
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-                />
-                {errors.start_date && (
-                  <p className="mt-1 text-xs text-red-500">
-                    {errors.start_date.message}
-                  </p>
-                )}
-              </div>
-
-              {/* 신청 마감일 */}
-              <div>
-                <label className="mb-1 block text-sm font-medium text-gray-700">
-                  신청 마감일 *
-                </label>
-                <input
-                  type="date"
-                  {...register("apply_deadline", {
-                    required: "신청 마감일은 필수입니다.",
-                  })}
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-                />
-                {errors.apply_deadline && (
-                  <p className="mt-1 text-xs text-red-500">
-                    {errors.apply_deadline.message}
-                  </p>
-                )}
-              </div>
+            {/* 시작 날짜 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                시작 날짜 *
+              </label>
+              <input
+                type="datetime-local"
+                {...register("start_date", {
+                  required: "시작 날짜는 필수입니다.",
+                })}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              />
+              {errors.start_date && (
+                <p className="mt-1 text-xs text-red-500">
+                  {errors.start_date.message}
+                </p>
+              )}
             </div>
 
             {/* 가격 */}

--- a/src/types/lectures.ts
+++ b/src/types/lectures.ts
@@ -35,7 +35,6 @@ export interface Lecture {
   content_text: string;
   url: string;
   start_date: string; // ISO string format
-  apply_deadline: string; // ISO string format (date only)
   price: string;
   coach_id: string; // 강사 ID 추가
   updated_at?: string;
@@ -50,7 +49,6 @@ export interface CreateLectureForm {
   content_text?: string;
   url: string;
   start_date: string;
-  apply_deadline: string;
   price: string;
   coach_id: string; // 강사 ID 추가
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝 작업 내용
- 강의 복제 기능 추가로 기존 강의를 복사하여 새 강의 생성 가능 (시작 날짜만 새로 설정)
- 강의 신청 마감일(`apply_deadline`) 필드를 제거하고 시작 날짜(`start_date`)로 통합
### 1. 신청 마감일 제거
- `apply_deadline` 필드를 모든 컴포넌트에서 제거
- 카운트다운 타이머가 `start_date`를 사용하도록 변경
- 관리자 페이지에서 날짜를 `2025-07-30 오후 08:00` 형식으로 표시

### 2. 강의 복제 기능 추가
- 관리자 강의 목록에 복제 버튼(Copy 아이콘) 추가
- 복제 시 시작 날짜를 제외한 모든 데이터(제목, 설명, 이미지, 가격, 강사 등) 복사
- 시작 날짜만 새로 입력하여 강의 생성
- 이미지는 기존 URL을 재사용하여 효율적인 복제

### 기타 개선사항
- 강의 생성 시 가격 기본값을 "무료"로 설정
- API 구조 개선으로 복제 모드와 생성 모드를 하나의 함수로 통합

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
