### PR TITLE
fix: 강의 복제 시 이미지 독립성 보장을 위한 복사 로직 추가

### DIFF
--- a/src/app/api/lectures.ts
+++ b/src/app/api/lectures.ts
@@ -32,9 +32,27 @@ export const lecturesApi = {
       let contentImagesUrl: string | null = null;
 
       if (isDuplicate) {
-        // 복제 모드: 기존 이미지 URL 사용
-        thumbnailUrl = formData.thumbnail;
-        contentImagesUrl = formData.content_image;
+        // 복제 모드: 기존 이미지를 다운로드하여 새로 업로드
+        if (formData.thumbnail) {
+          thumbnailUrl = await storageApi.downloadAndUploadFile(
+            formData.thumbnail,
+            "lecture-thumbnails"
+          );
+        } else {
+          thumbnailUrl = null;
+        }
+
+        if (formData.content_image) {
+          const imageUrls = formData.content_image.split(",").filter(url => url.trim());
+          if (imageUrls.length > 0) {
+            const duplicatedUrls = await Promise.all(
+              imageUrls.map(url => 
+                storageApi.downloadAndUploadFile(url.trim(), "lecture-content-images")
+              )
+            );
+            contentImagesUrl = duplicatedUrls.join(",");
+          }
+        }
       } else {
         // 일반 생성 모드: 새 이미지 업로드
         if (!thumbnailFile) {

--- a/src/app/api/storage.ts
+++ b/src/app/api/storage.ts
@@ -1,6 +1,27 @@
 import { supabase } from "@/utils/supabase";
 
 export const storageApi = {
+  downloadAndUploadFile: async (
+    imageUrl: string,
+    bucket: string,
+  ): Promise<string> => {
+    try {
+      const response = await fetch(imageUrl);
+      if (!response.ok) {
+        throw new Error(`이미지 다운로드 실패: ${response.statusText}`);
+      }
+
+      const blob = await response.blob();
+      const fileName = `${Date.now()}-duplicated-${Math.random().toString(36).substring(7)}.${blob.type.split('/')[1] || 'jpg'}`;
+      
+      const file = new File([blob], fileName, { type: blob.type });
+      return await storageApi.uploadFile(file, bucket);
+    } catch (error) {
+      console.error('이미지 복제 중 오류:', error);
+      throw new Error('이미지 복제에 실패했습니다.');
+    }
+  },
+
   uploadFile: async (
     file: File,
     bucket: string,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
### 문제
- 강의 복제 시 같은 이미지 URL을 참조하여 복제된 강의를 삭제할 때 원본 강의의 이미지도 함께 삭제되는 문제가 발생

### 해결방안
복제 시 기존 이미지를 다운로드하여 새로운 파일로 업로드하도록 로직 변경

### 변경사항
- **`storage.ts`**:`downloadAndUploadFile` 함수 추가
- 기존 이미지 URL에서 파일 다운로드
- 새로운 파일명으로 스토리지에 재업로드
- **`lectures.ts`**: 복제 모드 로직 개선
- 썸네일 이미지 독립 복사
- 콘텐츠 이미지들 독립 복사

### 효과
- 복제된 강의와 원본 강의의 이미지 독립성 보장
- 복제된 강의 삭제 시 원본 강의 이미지 보호
- 각 강의가 고유한 이미지 파일 소유

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
