### PR TITLE
fix: 이미지 복제 시 파일명 중복 생성 문제 해결

### DIFF
--- a/src/app/api/storage.ts
+++ b/src/app/api/storage.ts
@@ -15,7 +15,7 @@ export const storageApi = {
       const fileName = `${Date.now()}-duplicated-${Math.random().toString(36).substring(7)}.${blob.type.split('/')[1] || 'jpg'}`;
       
       const file = new File([blob], fileName, { type: blob.type });
-      return await storageApi.uploadFile(file, bucket);
+      return await storageApi.uploadFile(file, bucket, fileName);
     } catch (error) {
       console.error('이미지 복제 중 오류:', error);
       throw new Error('이미지 복제에 실패했습니다.');


### PR DESCRIPTION
## #️⃣연관된 이슈

>
## 📝작업 내용
- 이미지 복제 시 파일명 중복 생성 문제 해결했습니다.

### 문제
downloadAndUploadFile에서 파일명을 만들어도 uploadFile에서 path 파라미터가 없으면 다시 타임스탬프를 추가해서 중복되었습니다.

### 해결
uploadFile 호출 시 fileName을 path 파라미터로 전달하여 중복 타임스탬프 생성을 방지했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
