### PR TITLE
feat: 강의 상세페이지 강사 소개 영역에 bio, career 추가

### DIFF
--- a/src/app/(main)/lecture/[id]/page.tsx
+++ b/src/app/(main)/lecture/[id]/page.tsx
@@ -130,12 +130,24 @@ export default function CourseDetailPage() {
                     <div className="prose min-h-[200px] max-w-none lg:min-h-96">
                       <h2 className="mb-4 text-2xl font-bold">강사 소개</h2>
                       <div className="rounded-lg bg-gray-50 p-6">
-                        <h3 className="mb-2 text-xl font-bold">
+                        <h3 className="mb-4 text-xl font-bold">
                           {lecture.coach.name}
                         </h3>
-                        {/* <p className="leading-relaxed text-gray-700">
-                          {lecture.coach.bio}
-                        </p> */}
+                        {lecture.coach.bio && (
+                          <div className="mb-4">
+                            <p className="leading-relaxed text-gray-700">
+                              {lecture.coach.bio}
+                            </p>
+                          </div>
+                        )}
+                        {lecture.coach.career && (
+                          <div>
+                            <h4 className="mb-2 font-semibold">경력</h4>
+                            <p className="leading-relaxed whitespace-pre-line text-gray-700">
+                              {lecture.coach.career}
+                            </p>
+                          </div>
+                        )}
                       </div>
                     </div>
                   )}

--- a/src/app/api/lectures.ts
+++ b/src/app/api/lectures.ts
@@ -146,7 +146,7 @@ export const lecturesApi = {
       .select(
         `
         *,
-        coach:coaches!coach_id (id, name)
+        coach:coaches!coach_id (id, name, bio, career)
       `,
       )
       .eq("id", id)

--- a/src/types/lectures.ts
+++ b/src/types/lectures.ts
@@ -58,5 +58,7 @@ export interface LectureWithCoach extends Lecture {
   coach: {
     id: string;
     name: string;
+    bio?: string;
+    career?: string;
   };
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용
- 강의 상세페이지의 강사 소개 영역에 bio, career 추가했습니다.

### 스크린샷 (선택)
- 수정 전
<img width="1039" height="701" alt="스크린샷 2025-07-30 오후 8 35 17" src="https://github.com/user-attachments/assets/4ed9328b-b08a-4427-ace1-6b6043e814c5" />

- 수정 후
<img width="1050" height="714" alt="스크린샷 2025-07-30 오후 8 35 35" src="https://github.com/user-attachments/assets/3300e85e-a051-4c23-89dc-3c09a298357a" />

## 💬리뷰 요구사항(선택)

> 
